### PR TITLE
fix8: move import ui-data to ui_constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,13 @@ python manage.py migrate --run-syncdb
 ```
 
 Добавить данные в базу данных данные по умолчанию
+- пункты выдачи заказов и склады
 ```
 python manage.py import_data_from_csv
+```
+- текст элементов управления бота
+```
+python manage.py import_ui_data_from_csv
 ```
 
 Запустить сервер на локальной машине:

--- a/tgbot/parser/management/commands/import_data_from_csv.py
+++ b/tgbot/parser/management/commands/import_data_from_csv.py
@@ -1,5 +1,4 @@
 from csv import DictReader
-from ui_constructor.models import ButtonConstructor
 from parser.models import Destination, Storehouse
 from sys import exit
 
@@ -13,16 +12,12 @@ CSV_TABLES = {
     'Storehouse': DictReader(
         open('../data/storehouse.csv', encoding='utf-8')
     ),
-    'ButtonConstructor': DictReader(
-        open('../data/buttons.csv', encoding='utf-8')
-    ),
 }
 
 
 def delete_everything():
     Destination.objects.all().delete()
     Storehouse.objects.all().delete()
-    ButtonConstructor.objects.all().delete()
 
 
 def print_attention():
@@ -54,12 +49,5 @@ class Command(BaseCommand):
                 pk=value['id'],
                 name=value['name'],
                 index=value['index'],
-            )
-        for value in CSV_TABLES['ButtonConstructor']:
-            ButtonConstructor.objects.get_or_create(
-                pk=value['id'],
-                ui_control_id=value['ui_control_id'],
-                button_description=value['button_description'],
-                default_text=value['default_text'],
             )
         print('Данные по умолчанию добавлены в базу данных')

--- a/tgbot/ui_constructor/management/commands/import_ui_data_from_csv.py
+++ b/tgbot/ui_constructor/management/commands/import_ui_data_from_csv.py
@@ -1,0 +1,43 @@
+from csv import DictReader
+from ui_constructor.models import ButtonConstructor
+from sys import exit
+
+from django.core.management import BaseCommand
+
+
+CSV_TABLES = {
+    'ButtonConstructor': DictReader(
+        open('../data/buttons.csv', encoding='utf-8')
+    ),
+}
+
+
+def delete_everything():
+    ButtonConstructor.objects.all().delete()
+
+
+def print_attention():
+    print(
+        'Внимание! Будут сброшены в значения по умолчанию '
+        'тексты всех элементов управления бота. '
+        'Хотите продолжить ? [Y / N]: '
+    )
+    answer = input()
+    if answer.upper() != 'Y':
+        exit()
+
+
+print_attention()
+delete_everything()
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        for value in CSV_TABLES['ButtonConstructor']:
+            ButtonConstructor.objects.get_or_create(
+                pk=value['id'],
+                ui_control_id=value['ui_control_id'],
+                button_description=value['button_description'],
+                default_text=value['default_text'],
+            )
+        print('Данные по умолчанию добавлены в базу данных')


### PR DESCRIPTION
Перенес импорт данных csv из parser в ui_constructor, протестировал, все работает.
Не совсем, конечно, DRY, но и высушить там можно немногое, учитывая потенциал развития, решил будет пока избыточно.